### PR TITLE
Fixes connection tracking issues

### DIFF
--- a/lib/HTTP/Server/Async.pm6
+++ b/lib/HTTP/Server/Async.pm6
@@ -73,7 +73,8 @@ class HTTP::Server::Async {
         for %!connections.keys -> $key {
           try {
             if (now - %!connections{$key}<now>).Int > $.timeout {
-              %!connections{$key}<connection>.close; 
+              %!connections{$key}<connection>.close;
+              %!connections{$key}:delete;
             }
           };
         }

--- a/lib/HTTP/Server/Async.pm6
+++ b/lib/HTTP/Server/Async.pm6
@@ -37,8 +37,8 @@ class HTTP::Server::Async {
     $!server.tap(-> $connection {
       my $id      = $connid++;
       my $tap     = $connection.chars_supply.tap(-> $data {
-        $!parser.send({ 
-          id         => $connid, 
+        $!parser.send({
+          id         => $id, 
           connection => $connection, 
           data       => $data,
           tap        => $tap,


### PR DESCRIPTION
i used to have a problem with requests stalling in the browser, now it's gone, but i'm not sure if this was really the issue.

also, the timeout worker had to do more and more work the more connections were opened so far, so i made it delete the connections from %!connections when the sockets get closed; not sure if that's actually the right place, though