### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/t/lib/starter.pm6
+++ b/t/lib/starter.pm6
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl6
-module starter;
+unit module starter;
 
 use lib 'lib';
 use HTTP::Server::Async;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.