### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/01_request.t
+++ b/t/01_request.t
@@ -7,7 +7,7 @@ use Test;
 plan 11;
 
 my $s = srv;
-isa_ok $s, HTTP::Server::Async;
+isa-ok $s, HTTP::Server::Async;
 is $s.responsestack.elems, 0, 'Response stack contains no elements yet';
 
 $s.register(sub ($req,$res,$n) {
@@ -25,13 +25,13 @@ $s.register(sub ($request, $response, $n) {
   $response.close("Hello world!");
 });
 ok $s.responsestack.elems, 'Response stack contains elements';
-isa_ok $s.responsestack[0], Sub;
+isa-ok $s.responsestack[0], Sub;
 
 $s.listen;
 
  
 my $client = req;
-isa_ok $client, IO::Socket::INET;
+isa-ok $client, IO::Socket::INET;
 is $client.host, host, 'IO::Socket::INET correct host';
 is $client.port, port, 'IO::Socket::INET correct port';
 

--- a/t/09_unbuffer.t
+++ b/t/09_unbuffer.t
@@ -7,7 +7,7 @@ use Test;
 plan 11;
 
 my $s = srv;
-isa_ok $s, HTTP::Server::Async;
+isa-ok $s, HTTP::Server::Async;
 is $s.responsestack.elems, 0, 'Response stack contains no elements yet';
 
 $s.register(sub ($req,$res,$n) {
@@ -29,13 +29,13 @@ $s.register(sub ($request, $response, $n) {
   };
 });
 ok $s.responsestack.elems, 'Response stack contains elements';
-isa_ok $s.responsestack[0], Sub;
+isa-ok $s.responsestack[0], Sub;
 
 $s.listen;
 
  
 my $client = req;
-isa_ok $client, IO::Socket::INET;
+isa-ok $client, IO::Socket::INET;
 is $client.host, host, 'IO::Socket::INET correct host';
 is $client.port, port, 'IO::Socket::INET correct port';
 


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.