### PR TITLE
Specify HTTP::Request/Response more specifically

### DIFF
--- a/lib/HTTP/Server/Async.pm6
+++ b/lib/HTTP/Server/Async.pm6
@@ -1,4 +1,4 @@
-use HTTP::Server;
+use HTTP::Server:auth<github:tony-o>;
 use HTTP::Server::Async::Request;
 use HTTP::Server::Async::Response;
 

--- a/lib/HTTP/Server/Async/Request.pm6
+++ b/lib/HTTP/Server/Async/Request.pm6
@@ -1,4 +1,4 @@
-use HTTP::Request;
+use HTTP::Request:auth<github:tony-o>;
 use HTTP::Server::Async::Response;
 
 class HTTP::Server::Async::Request does HTTP::Request {

--- a/lib/HTTP/Server/Async/Response.pm6
+++ b/lib/HTTP/Server/Async/Response.pm6
@@ -1,4 +1,4 @@
-use HTTP::Response;
+use HTTP::Response:auth<github:tony-o>;
 
 class HTTP::Server::Async::Response does HTTP::Response {
   has @!buffer;


### PR DESCRIPTION
Since HTTP::UserAgent also defines a HTTP::Request and HTTP::Response,
this module will not install if HTTP::UserAgent is also installed.
Adding an author restriction means we get the HTTP::Request we expect.

Fixes #21; requires https://github.com/tony-o/perl6-http-server/pull/1 to be merged