### PR TITLE
Qualify use of HTTP::Response and HTTP::Request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.precomp

--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "HTTP::Server::Async",
-  "version"     : "0.1.1",
+  "version"     : "0.1.2",
   "description" : "Asynchronous Base HTTP Server",
   "authors"     : [ "tony-o", "Wenzel P. P. Peppmeyer" ],
   "auth"        : "github:tony-o",

--- a/lib/HTTP/Server/Async/Request.pm6
+++ b/lib/HTTP/Server/Async/Request.pm6
@@ -1,4 +1,4 @@
-use HTTP::Request;
+use HTTP::Request:auth<github:tony-o>;
 use HTTP::Server::Async::Response;
 
 class HTTP::Server::Async::Request does HTTP::Request {

--- a/lib/HTTP/Server/Async/Response.pm6
+++ b/lib/HTTP/Server/Async/Response.pm6
@@ -1,4 +1,4 @@
-use HTTP::Response;
+use HTTP::Response:auth<github:tony-o>;
 
 class HTTP::Server::Async::Response does HTTP::Response {
   has @!buffer;


### PR DESCRIPTION
I've been meaning to do this for ages so that it co-habits nicely with HTTP::UserAgent (which I have similarly fixed,)  all good for me now :)